### PR TITLE
Add Node.js Org docs to comply with ownership transfer

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,33 @@
+<!--
+Before submitting a pull request, please read the Node.js project contributing guidelines:
+https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
+
+Commit message formatting guidelines:
+https://github.com/nodejs/node/blob/HEAD/doc/guides/contributing/pull-requests.md#commit-message-guidelines
+
+Developer's Certificate of Origin 1.1
+
+By making a contribution to this project, I certify that:
+
+(a) The contribution was created in whole or in part by me and I
+    have the right to submit it under the open source license
+    indicated in the file; or
+
+(b) The contribution is based upon previous work that, to the best
+    of my knowledge, is covered under an appropriate open source
+    license and I have the right under that license to submit that
+    work with modifications, whether created in whole or in part
+    by me, under the same open source license (unless I am
+    permitted to submit under a different license), as indicated
+    in the file; or
+
+(c) The contribution was provided directly to me by some other
+    person who certified (a), (b) or (c) and I have not modified
+    it.
+
+(d) I understand and agree that this project and the contribution
+    are public and that a record of the contribution (including all
+    personal information I submit with it, including my sign-off) is
+    maintained indefinitely and may be redistributed consistent with
+    this project or the open source license(s) involved.
+-->

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,2 @@
+## Code of Conduct
+The [Node.js Code of Conduct](https://github.com/nodejs/admin/blob/HEAD/CODE_OF_CONDUCT.md) applies to this repository.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,46 @@
+# Contributing to `icu4c-data-npm`
+
+## What is `icu4c-data-npm`?
+
+### About ICU
+International Components for Unicode (ICU) is an open-source project of mature C/C++ and Java libraries for Unicode support, software internationalization, and software globalization. ICU is widely portable to many operating systems and environments, and is an initiative of the [Unicode Consortium](https://home.unicode.org/).
+
+Node.js uses ICU to implement these features in native C/C++ code. The full ICU data set is provided in Node.js by default, and the [full-icu package](https://www.npmjs.com/package/full-icu) is how it is provisioned to node.
+
+### About the ICU4C Data module
+This module JSONifies the ICU data that is available for available for use in C/C++, and makes that data available for use in JavaScript environments. It is the data by which [`full-icu`](https://www.npmjs.com/package/full-icu) is dependent on.
+
+**We are thankful for Your interest in contributing to this effort!**
+
+> You can read more about how to use it in Node.js in the [Node.js Intl API](https://nodejs.org/api/intl.html) documentation.
+
+## Code of Conduct
+Contributors to this repository must adhere to the [Node.js Code of Conduct](https://github.com/nodejs/admin/blob/HEAD/CODE_OF_CONDUCT.md).
+
+For more information on the Node.js Code of Conduct please review these [policy details](https://github.com/nodejs/node/blob/master/doc/guides/contributing/code-of-conduct.md).
+
+## Developer's Certificate of Origin 1.1
+
+By making a contribution to this project, I certify that:
+
+ (a) The contribution was created in whole or in part by me and I
+     have the right to submit it under the open source license
+     indicated in the file; or
+
+ (b) The contribution is based upon previous work that, to the best
+     of my knowledge, is covered under an appropriate open source
+     license and I have the right under that license to submit that
+     work with modifications, whether created in whole or in part
+     by me, under the same open source license (unless I am
+     permitted to submit under a different license), as indicated
+     in the file; or
+
+ (c) The contribution was provided directly to me by some other
+     person who certified (a), (b) or (c) and I have not modified
+     it.
+
+ (d) I understand and agree that this project and the contribution
+     are public and that a record of the contribution (including all
+     personal information I submit with it, including my sign-off) is
+     maintained indefinitely and may be redistributed consistent with
+     this project or the open source license(s) involved.

--- a/LICENSE
+++ b/LICENSE
@@ -1,46 +1,25 @@
-﻿UNICODE, INC. LICENSE AGREEMENT - DATA FILES AND SOFTWARE
+## LICENSE
 
-See Terms of Use for definitions of Unicode Inc.'s
-Data Files and Software.
+The MIT License (MIT)
 
-NOTICE TO USER: Carefully read the following legal agreement.
-BY DOWNLOADING, INSTALLING, COPYING OR OTHERWISE USING UNICODE INC.'S
-DATA FILES ("DATA FILES"), AND/OR SOFTWARE ("SOFTWARE"),
-YOU UNEQUIVOCALLY ACCEPT, AND AGREE TO BE BOUND BY, ALL OF THE
-TERMS AND CONDITIONS OF THIS AGREEMENT.
-IF YOU DO NOT AGREE, DO NOT DOWNLOAD, INSTALL, COPY, DISTRIBUTE OR USE
-THE DATA FILES OR SOFTWARE.
+Copyright Node.js contributors. All rights reserved.
 
-COPYRIGHT AND PERMISSION NOTICE
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
 
-Copyright © 1991-2021 Unicode, Inc. All rights reserved.
-Distributed under the Terms of Use in https://www.unicode.org/copyright.html.
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
 
-Permission is hereby granted, free of charge, to any person obtaining
-a copy of the Unicode data files and any associated documentation
-(the "Data Files") or Unicode software and any associated documentation
-(the "Software") to deal in the Data Files or Software
-without restriction, including without limitation the rights to use,
-copy, modify, merge, publish, distribute, and/or sell copies of
-the Data Files or Software, and to permit persons to whom the Data Files
-or Software are furnished to do so, provided that either
-(a) this copyright and permission notice appear with all copies
-of the Data Files or Software, or
-(b) this copyright and permission notice appear in associated
-Documentation.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
 
-THE DATA FILES AND SOFTWARE ARE PROVIDED "AS IS", WITHOUT WARRANTY OF
-ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
-WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
-NONINFRINGEMENT OF THIRD PARTY RIGHTS.
-IN NO EVENT SHALL THE COPYRIGHT HOLDER OR HOLDERS INCLUDED IN THIS
-NOTICE BE LIABLE FOR ANY CLAIM, OR ANY SPECIAL INDIRECT OR CONSEQUENTIAL
-DAMAGES, OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE,
-DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER
-TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
-PERFORMANCE OF THE DATA FILES OR SOFTWARE.
-
-Except as contained in this notice, the name of a copyright holder
-shall not be used in advertising or otherwise to promote the sale,
-use or other dealings in these Data Files or Software without prior
-written authorization of the copyright holder.
+This repository is also subject to the [Node.js license](https://github.com/nodejs/node/blob/master/LICENSE) in general, and the [Unicode License](./unicode-license.txt).

--- a/README.md
+++ b/README.md
@@ -1,44 +1,43 @@
-ICU4C Data Packager for Node
-###
+# `icu4c-data`
 
-# Future Obsolescence?
+An ICU4C Data Packager for Node.js
 
-See https://github.com/unicode-org/full-icu-npm/issues/36 — no updates are planned for ICU 65 and following, for little endian intel.
+> Note: This module may become obsolete, please refer to [this issue](https://github.com/unicode-org/full-icu-npm/issues/36) accordingly. No updates have been planned for ICU 65 and above, in regards to little endian Intel systems.
 
-Background
----
+## About `icu4c-data`
 
-This is the data package builder for the [full-icu](https://www.npmjs.com/package/full-icu) package. See that if you just want to install ICU data.
+This is the data package builder for the [full-icu](https://www.npmjs.com/package/full-icu) module. Please refer to [full-icu](https://www.npmjs.com/package/full-icu) if you only want to install ICU data.
 
-Usage: Building the data
----
+## Use: Building the data
 
-To use, first get the data file, such as `icudt58l.dat` from an ICU build or from the official ICU source tarball (.tgz/.zip)
+To use this module: first acquire the data file, such as `icudt58l.dat` from an ICU build, or from the official ICU source tarball (.tgz/.zip).
 
-You may be able to use the following script to do so if `bash` is available:
+1. You can use the following script to do so in `bash`:
 
-    bash fetchdata.sh 58.2
+```
+bash fetchdata.sh 58.2
+```
 
-Then, publish the little-endian file
+2. Then publish the little-endian file
 
-    npm run gen -- icudt58l.dat
+```
+npm run gen -- icudt58l.dat
+```
 
-This will output a line labelled "run this command". (starting with `rm …`) Run that command after each `npm run gen`.
+This will output a line labelled 'run this command' (starting with `rm …`). Run that command after each time you execute `npm run gen`.
 
-Now publish the big endian file.
+3. Now publish the big endian file.
 
-    npm run gen -- icudt58b.dat
-    # (remember to run the commands instructed)
+`npm run gen -- icudt58b.dat`
 
-LICENSE
-===
+> Remember to run the commands as instructed in section 2.
 
-- Usage of data and software is governed by the [Unicode Terms of Use](http://www.unicode.org/copyright.html)
-a copy of which is included as [LICENSE](./LICENSE)
+## LICENSE
 
-COPYRIGHT
-===
+This repository is subject to the terms under the [Node.js license](https://github.com/nodejs/node/blob/master/LICENSE). Some usage of this data is governed by the [Unicode Terms of Use](http://www.unicode.org/copyright.html), which is included in the [unicode-license.txt](./unicode-license.txt)
 
-Copyright &copy; 1991-2021 Unicode, Inc.
-All rights reserved.
-[Terms of use](http://www.unicode.org/copyright.html)
+## COPYRIGHT
+
+Copyright &copy; 1991-2021 Unicode, Inc. and Node.js contributors. All rights reserved.
+
+[Unicode terms of use](http://www.unicode.org/copyright.html)

--- a/unicode-license.txt
+++ b/unicode-license.txt
@@ -1,0 +1,46 @@
+﻿UNICODE, INC. LICENSE AGREEMENT - DATA FILES AND SOFTWARE
+
+See Terms of Use for definitions of Unicode Inc.'s
+Data Files and Software.
+
+NOTICE TO USER: Carefully read the following legal agreement.
+BY DOWNLOADING, INSTALLING, COPYING OR OTHERWISE USING UNICODE INC.'S
+DATA FILES ("DATA FILES"), AND/OR SOFTWARE ("SOFTWARE"),
+YOU UNEQUIVOCALLY ACCEPT, AND AGREE TO BE BOUND BY, ALL OF THE
+TERMS AND CONDITIONS OF THIS AGREEMENT.
+IF YOU DO NOT AGREE, DO NOT DOWNLOAD, INSTALL, COPY, DISTRIBUTE OR USE
+THE DATA FILES OR SOFTWARE.
+
+COPYRIGHT AND PERMISSION NOTICE
+
+Copyright © 1991-2021 Unicode, Inc. All rights reserved.
+Distributed under the Terms of Use in https://www.unicode.org/copyright.html.
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of the Unicode data files and any associated documentation
+(the "Data Files") or Unicode software and any associated documentation
+(the "Software") to deal in the Data Files or Software
+without restriction, including without limitation the rights to use,
+copy, modify, merge, publish, distribute, and/or sell copies of
+the Data Files or Software, and to permit persons to whom the Data Files
+or Software are furnished to do so, provided that either
+(a) this copyright and permission notice appear with all copies
+of the Data Files or Software, or
+(b) this copyright and permission notice appear in associated
+Documentation.
+
+THE DATA FILES AND SOFTWARE ARE PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT OF THIRD PARTY RIGHTS.
+IN NO EVENT SHALL THE COPYRIGHT HOLDER OR HOLDERS INCLUDED IN THIS
+NOTICE BE LIABLE FOR ANY CLAIM, OR ANY SPECIAL INDIRECT OR CONSEQUENTIAL
+DAMAGES, OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE,
+DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER
+TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+PERFORMANCE OF THE DATA FILES OR SOFTWARE.
+
+Except as contained in this notice, the name of a copyright holder
+shall not be used in advertising or otherwise to promote the sale,
+use or other dealings in these Data Files or Software without prior
+written authorization of the copyright holder.


### PR DESCRIPTION
## Description
In accordance with the intention of transferring the ownership of this module from the Unicode Org to Node.js, this commit adds all the necessary documents that Node.js requires (in compliance with policies of the OpenJS Foundation, which Node.js is subject to) in order to validate this transfer.

## Precedent
The original issue can be viewed [here](https://github.com/nodejs/admin/issues/532), please review for context.